### PR TITLE
Link to meteor examples using keyUp 13

### DIFF
--- a/cookbook/keybinding.md
+++ b/cookbook/keybinding.md
@@ -14,7 +14,7 @@ http://unicode-table.com/en/#control-character
 
 
 **Submitting Data**  
-Here's a common pattern for submitting data to your app, instead of binding to the ``submit`` event.  Basically, we're binding to the ``keyup`` event instead, looking for keycode 13, and if we detect it, setting a reactive Session variable.  This is a preferred Meteor-centric approach to submitting data in forms.  
+Here's a common pattern for submitting data to your app, instead of binding to the ``submit`` event.  Basically, we're binding to the ``keyup`` event instead, looking for keycode 13, and if we detect it, setting a reactive Session variable.  This is a [preferred](https://github.com/meteor/meteor/blob/devel/examples/todos/client/todos.js#L59) [Meteor-centric](https://github.com/meteor/meteor/blob/devel/examples/wordplay/client/wordplay.js#L135) approach to submitting data in forms because [[TBD]].
 ````js
 Template.navbarHeaderTemplate.events({
   'keyup #urlAddressBar': function(evt,tmpl){


### PR DESCRIPTION
Would be great to mention why exactly binding to the 'submit' event isn't a good idea. What about touch devices? Is there a synthetic keyUp generated when the user taps the submit button?
