### PR TITLE
Comparison table is not on the features page

### DIFF
--- a/cookbook/test-driven-development.md
+++ b/cookbook/test-driven-development.md
@@ -10,7 +10,7 @@ For an introduction to different types of tests (unit, integration, functional, 
 So, the bad news is that the test driven development in Meteor is still somewhat in its infancy.  The good news is that it's starting to mature, with a number of different approaches being investigated.  So, maybe it's more of a toddler than an infant.   
 
 Regardless, if you'd like a comprehensive rundown of the options, keep tabs on the following feature comparison table:  
-http://safety-harness.meteor.com/features
+http://safety-harness.meteor.com/comparison
 
 #### [Tinytest](https://github.com/meteor/meteor/tree/devel/packages/tinytest)
 


### PR DESCRIPTION
Just adding the correct URL for the Meteor testing comparisons
