### PR TITLE
Fix link to meteor snippets

### DIFF
--- a/cookbook/webstorm.md
+++ b/cookbook/webstorm.md
@@ -1,7 +1,7 @@
 ## WebStorm IDE
 
 **Note:  WebStorm is no longer the Meteor-Cookbook recommended Editor or Development Environment.**   
-We now recommend [Atom.io](http://www.atom.io) since it's a pure-javascript editor, meaning we can extend the Meteor Isomorphic API to the Editor.  For an early preview, check out [Meteor API Code Snippets for Atom Editor](https://github.com/awatson1978/meteor-api-for-atom-editor).  
+We now recommend [Atom.io](http://www.atom.io) since it's a pure-javascript editor, meaning we can extend the Meteor Isomorphic API to the Editor.  For an early preview, check out [Meteor API Code Snippets for Atom Editor](https://github.com/ThusStyles/meteor-snippets).  
 
 ================================================
 #### Version  


### PR DESCRIPTION
Was linking to meteor-api-old which I think is not correct.
